### PR TITLE
Don't create a close button automatically

### DIFF
--- a/index.css
+++ b/index.css
@@ -9,13 +9,3 @@ details-dialog {
   max-height: 80vh;
   width: 448px;
 }
-
-details-dialog .dd-close-button {
-  background: none;
-  position: absolute;
-  right: 0;
-  top: 0;
-  padding: 20px;
-  border: 0;
-  line-height: 0;
-}

--- a/index.js
+++ b/index.js
@@ -1,15 +1,6 @@
 const CLOSE_ATTR = 'data-close-dialog'
 const CLOSE_SELECTOR = `[${CLOSE_ATTR}]`
-
-function createCloseButton() {
-  const button = document.createElement('button')
-  button.innerHTML = closeIcon()
-  button.classList.add('dd-close-button')
-  button.setAttribute('type', 'button')
-  button.setAttribute('aria-label', 'Close dialog')
-  button.setAttribute(CLOSE_ATTR, true)
-  return button
-}
+const INPUT_SELECTOR = 'a, input, button, textarea'
 
 function autofocus(el) {
   let autofocus = el.querySelector('[autofocus]')
@@ -36,7 +27,7 @@ function restrictTabBehavior(event) {
   event.preventDefault()
 
   const dialog = event.currentTarget
-  const elements = Array.from(dialog.querySelectorAll('a, input, button, textarea')).filter(focusable)
+  const elements = Array.from(dialog.querySelectorAll(INPUT_SELECTOR)).filter(focusable)
 
   const movement = event.shiftKey ? -1 : 1
   const currentFocus = elements.filter(el => el.matches(':focus'))[0]
@@ -51,12 +42,6 @@ function restrictTabBehavior(event) {
   }
 
   elements[targetIndex].focus()
-}
-
-// Pulled from https://github.com/primer/octicons
-// We're only using one octicon so it doesn't make sense to include the whole module
-function closeIcon() {
-  return '<svg version="1.1" width="12" height="16" viewBox="0 0 12 16" aria-hidden="true"><path d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48z"/></svg>'
 }
 
 function toggle(event) {
@@ -84,10 +69,13 @@ class DetailsDialogElement extends HTMLElement {
   static get CLOSE_SELECTOR() {
     return CLOSE_SELECTOR
   }
+  static get INPUT_SELECTOR() {
+    return INPUT_SELECTOR
+  }
 
   constructor() {
     super()
-    initialized.set(this, {rendered: false, details: null})
+    initialized.set(this, {details: null})
     this.addEventListener('click', event => {
       if (event.target.closest(CLOSE_SELECTOR)) {
         event.target.closest('details').open = false
@@ -98,14 +86,6 @@ class DetailsDialogElement extends HTMLElement {
   connectedCallback() {
     this.setAttribute('role', 'dialog')
     const state = initialized.get(this)
-
-    if (!state.rendered) {
-      if (!this.querySelector(CLOSE_SELECTOR)) {
-        this.appendChild(createCloseButton())
-      }
-      state.rendered = true
-    }
-
     const details = this.parentElement
     details.addEventListener('toggle', toggle, {capture: true})
     state.details = details

--- a/index.js
+++ b/index.js
@@ -1,10 +1,13 @@
+const CLOSE_ATTR = 'data-close-dialog'
+const CLOSE_SELECTOR = `[${CLOSE_ATTR}]`
+
 function createCloseButton() {
   const button = document.createElement('button')
   button.innerHTML = closeIcon()
   button.classList.add('dd-close-button')
   button.setAttribute('type', 'button')
   button.setAttribute('aria-label', 'Close dialog')
-  button.setAttribute('data-close-dialog', true)
+  button.setAttribute(CLOSE_ATTR, true)
   return button
 }
 
@@ -75,11 +78,18 @@ function toggle(event) {
 const initialized = new WeakMap()
 
 class DetailsDialogElement extends HTMLElement {
+  static get CLOSE_ATTR() {
+    return CLOSE_ATTR
+  }
+  static get CLOSE_SELECTOR() {
+    return CLOSE_SELECTOR
+  }
+
   constructor() {
     super()
     initialized.set(this, {rendered: false, details: null})
     this.addEventListener('click', event => {
-      if (event.target.closest('[data-close-dialog]')) {
+      if (event.target.closest(CLOSE_SELECTOR)) {
         event.target.closest('details').open = false
       }
     })
@@ -90,7 +100,9 @@ class DetailsDialogElement extends HTMLElement {
     const state = initialized.get(this)
 
     if (!state.rendered) {
-      this.appendChild(createCloseButton())
+      if (!this.querySelector(CLOSE_SELECTOR)) {
+        this.appendChild(createCloseButton())
+      }
       state.rendered = true
     }
 
@@ -112,6 +124,8 @@ class DetailsDialogElement extends HTMLElement {
     }
   }
 }
+
+export default DetailsDialogElement
 
 if (!window.customElements.get('details-dialog')) {
   window.DetailsDialogElement = DetailsDialogElement

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@github/details-dialog-element",
+  "name": "details-dialog-element",
   "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -121,16 +121,6 @@
         "esutils": "2.0.2",
         "lodash": "4.17.4",
         "to-fast-properties": "2.0.0"
-      }
-    },
-    "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
       }
     },
     "accepts": {
@@ -1416,9 +1406,9 @@
       "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
         "combine-source-map": "0.8.0",
         "defined": "1.0.0",
+        "JSONStream": "1.3.2",
         "safe-buffer": "5.1.1",
         "through2": "2.0.3",
         "umd": "3.0.3"
@@ -1453,7 +1443,6 @@
       "integrity": "sha512-gKfOsNQv/toWz+60nSPfYzuwSEdzvV2WdxrVPUbPD/qui44rAkB3t3muNtmmGYHqrG56FGwX9SUEQmzNLAeS7g==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
         "assert": "1.4.1",
         "browser-pack": "6.1.0",
         "browser-resolve": "1.11.2",
@@ -1475,6 +1464,7 @@
         "https-browserify": "1.0.0",
         "inherits": "2.0.3",
         "insert-module-globals": "7.0.5",
+        "JSONStream": "1.3.2",
         "labeled-stream-splicer": "2.0.1",
         "module-deps": "4.1.1",
         "os-browserify": "0.3.0",
@@ -3962,6 +3952,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3970,14 +3968,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4649,10 +4639,10 @@
       "integrity": "sha512-wgRtrCpMm0ruH2hgLUIx+9YfJsgJQmU1KkPUzTuatW9dbH19yPRqAQhFX1HJU6zbmg2IMmt80BgSE5MWuksw3Q==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
         "combine-source-map": "0.8.0",
         "concat-stream": "1.6.2",
         "is-buffer": "1.1.6",
+        "JSONStream": "1.3.2",
         "lexical-scope": "1.2.0",
         "process": "0.11.10",
         "through2": "2.0.3",
@@ -5042,6 +5032,16 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true,
       "optional": true
+    },
+    "JSONStream": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -5760,7 +5760,6 @@
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
         "browser-resolve": "1.11.2",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
@@ -5768,6 +5767,7 @@
         "detective": "4.7.1",
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
+        "JSONStream": "1.3.2",
         "parents": "1.0.1",
         "readable-stream": "2.3.3",
         "resolve": "1.6.0",
@@ -7386,6 +7386,15 @@
         "readable-stream": "2.3.3"
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -7394,15 +7403,6 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/test/test.js
+++ b/test/test.js
@@ -62,4 +62,33 @@ describe('details-dialog-element', function() {
       assert.equal(1, dialog.querySelectorAll('[data-close-dialog').length)
     })
   })
+
+  describe('custom close button', function() {
+    let customButton
+
+    beforeEach(function() {
+      const container = document.createElement('div')
+      container.innerHTML = `
+      <details>
+        <summary>Click</summary>
+        <details-dialog>
+          <p>Hello</p>
+          <button data-close-dialog>Say goodbye</button>
+        </details-dialog>
+      </details>`
+      customButton = container.querySelector('[data-close-dialog]')
+      document.body.append(container)
+    })
+
+    afterEach(function() {
+      document.body.innerHTML = ''
+    })
+
+    it('creates a close button', function() {
+      const buttons = document.querySelectorAll('[data-close-dialog]')
+      const [firstButton] = buttons
+      assert.equal(buttons.length, 1, `More than one button (${buttons.length})`)
+      assert.strictEqual(firstButton, customButton, `Wrong button: ${firstButton.outerHTML}`)
+    })
+  })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,5 @@
+const {CLOSE_ATTR, CLOSE_SELECTOR} = window.DetailsDialogElement
+
 describe('details-dialog-element', function() {
   describe('element creation', function() {
     it('creates from document.createElement', function() {
@@ -15,21 +17,19 @@ describe('details-dialog-element', function() {
     beforeEach(function() {
       const container = document.createElement('div')
       container.innerHTML = `
-      <details>
-        <summary>Click</summary>
-        <details-dialog>
-          <p>Hello</p>
-        </details-dialog>
-      </details>`
+        <details>
+          <summary>Click</summary>
+          <details-dialog>
+            <p>Hello</p>
+            <button ${CLOSE_ATTR}>Goodbye</button>
+          </details-dialog>
+        </details>
+      `
       document.body.append(container)
     })
 
     afterEach(function() {
       document.body.innerHTML = ''
-    })
-
-    it('creates a close button', function() {
-      assert(document.querySelector('details-dialog button[data-close-dialog]'))
     })
 
     it('toggles open', function() {
@@ -45,7 +45,7 @@ describe('details-dialog-element', function() {
     it('closes with close button', function() {
       const details = document.querySelector('details')
       const dialog = details.querySelector('details-dialog')
-      const close = dialog.querySelector('[data-close-dialog')
+      const close = dialog.querySelector(CLOSE_SELECTOR)
       assert(!details.open)
       dialog.toggle(true)
       assert(details.open)
@@ -53,30 +53,31 @@ describe('details-dialog-element', function() {
       assert(!details.open)
     })
 
-    it('renders a single close button', function() {
+    xit('renders a single close button', function() {
       const details = document.querySelector('details')
       const dialog = details.querySelector('details-dialog')
-      assert.equal(1, dialog.querySelectorAll('[data-close-dialog').length)
+      assert.equal(1, dialog.querySelectorAll(CLOSE_SELECTOR).length)
       dialog.remove()
       details.append(dialog)
-      assert.equal(1, dialog.querySelectorAll('[data-close-dialog').length)
+      assert.equal(1, dialog.querySelectorAll(CLOSE_SELECTOR).length)
     })
   })
 
-  describe('custom close button', function() {
+  xdescribe('custom close button', function() {
     let customButton
 
     beforeEach(function() {
       const container = document.createElement('div')
       container.innerHTML = `
-      <details>
-        <summary>Click</summary>
-        <details-dialog>
-          <p>Hello</p>
-          <button data-close-dialog>Say goodbye</button>
-        </details-dialog>
-      </details>`
-      customButton = container.querySelector('[data-close-dialog]')
+        <details>
+          <summary>Click</summary>
+          <details-dialog>
+            <p>Hello</p>
+            <button ${CLOSE_ATTR}>Say goodbye</button>
+          </details-dialog>
+        </details>
+      `
+      customButton = container.querySelector(CLOSE_SELECTOR)
       document.body.append(container)
     })
 
@@ -85,7 +86,7 @@ describe('details-dialog-element', function() {
     })
 
     it('creates a close button', function() {
-      const buttons = document.querySelectorAll('[data-close-dialog]')
+      const buttons = document.querySelectorAll(CLOSE_SELECTOR)
       const [firstButton] = buttons
       assert.equal(buttons.length, 1, `More than one button (${buttons.length})`)
       assert.strictEqual(firstButton, customButton, `Wrong button: ${firstButton.outerHTML}`)

--- a/test/test.js
+++ b/test/test.js
@@ -52,44 +52,5 @@ describe('details-dialog-element', function() {
       close.click()
       assert(!details.open)
     })
-
-    xit('renders a single close button', function() {
-      const details = document.querySelector('details')
-      const dialog = details.querySelector('details-dialog')
-      assert.equal(1, dialog.querySelectorAll(CLOSE_SELECTOR).length)
-      dialog.remove()
-      details.append(dialog)
-      assert.equal(1, dialog.querySelectorAll(CLOSE_SELECTOR).length)
-    })
-  })
-
-  xdescribe('custom close button', function() {
-    let customButton
-
-    beforeEach(function() {
-      const container = document.createElement('div')
-      container.innerHTML = `
-        <details>
-          <summary>Click</summary>
-          <details-dialog>
-            <p>Hello</p>
-            <button ${CLOSE_ATTR}>Say goodbye</button>
-          </details-dialog>
-        </details>
-      `
-      customButton = container.querySelector(CLOSE_SELECTOR)
-      document.body.append(container)
-    })
-
-    afterEach(function() {
-      document.body.innerHTML = ''
-    })
-
-    it('creates a close button', function() {
-      const buttons = document.querySelectorAll(CLOSE_SELECTOR)
-      const [firstButton] = buttons
-      assert.equal(buttons.length, 1, `More than one button (${buttons.length})`)
-      assert.strictEqual(firstButton, customButton, `Wrong button: ${firstButton.outerHTML}`)
-    })
   })
 })


### PR DESCRIPTION
Removes the automatically added close button in favor or allowing implementors to supply their own. Originally it did this:

> Fixes #10 by checking for whether a close button (`[data-close-dialog]`) exists in the DOM before adding one automatically. There's a simple test for it, which passes! 🎉

But after some discussion, we agreed that nixing the close button altogether was the best move.

I've also introduced `CLOSE_ATTR`, `CLOSE_SELECTOR`, and `INPUT_SELECTOR` constants to keep things dry, and exposed them as static members of the (now `default`-exported) custom element class, which means that you can do this in other modules, e.g. in React:

```js
import DetailsDialog from 'details-dialog-element'
import React from 'react'

const closeProps = {
  [DetailsDialog.CLOSE_ATTR]: true
}

export default ({children, ...rest}) => (
  <details-dialog {...rest}>
    {children}
    <button {...closeProps}>Close me!</button>
  </details-dialog>
)
```