### PR TITLE
Remove capture

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,13 +87,13 @@ class DetailsDialogElement extends HTMLElement {
     this.setAttribute('role', 'dialog')
     const state = initialized.get(this)
     const details = this.parentElement
-    details.addEventListener('toggle', toggle, {capture: true})
+    details.addEventListener('toggle', toggle)
     state.details = details
   }
 
   disconnectedCallback() {
     const state = initialized.get(this)
-    state.details.removeEventListener('toggle', toggle, {capture: true})
+    state.details.removeEventListener('toggle', toggle)
     state.details = null
   }
 


### PR DESCRIPTION
We have other details event listeners using capture due do event delegation, these ones aren't. I'm removing them to avoid future confusion.

cc @dgraham I'll do a release after this, do you think #11 deserve a major version bump? 