### PR TITLE
Add max width set to 90vw

### DIFF
--- a/index.css
+++ b/index.css
@@ -7,5 +7,6 @@ details-dialog {
   transform: translateX(-50%);
   z-index: 999;
   max-height: 80vh;
+  max-width: 90vw;
   width: 448px;
 }


### PR DESCRIPTION
This pull request sets a `max-width` of `90vw` on the dialogs so they don't become wider than the screen on narrow screens.

| Before | After |
| --- | --- |
| <img width="580" alt="screen shot 2018-07-20 at 10 28 28 am" src="https://user-images.githubusercontent.com/671378/43016493-e0f1a6c2-8c07-11e8-9f65-89ecb23ad6fd.png">|<img width="580" alt="screen shot 2018-07-20 at 10 27 58 am" src="https://user-images.githubusercontent.com/671378/43016491-de2c2214-8c07-11e8-9413-cb566e2f2edb.png"> |

/cc @jonrohan since we were discussing this a bit yesterday
