### PR TITLE
Fix querying focusable elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,9 +24,10 @@ function focusable(el) {
 }
 
 function restrictTabBehavior(event) {
+  const dialog = event.currentTarget.querySelector('details-dialog')
+  if (!dialog) return
   event.preventDefault()
 
-  const dialog = event.currentTarget
   const elements = Array.from(dialog.querySelectorAll(INPUT_SELECTOR)).filter(focusable)
 
   const movement = event.shiftKey ? -1 : 1


### PR DESCRIPTION
Bug introduced in #16. When tab is trapped, the `<summary>` element outside the dialog was being focused on, because `event.currenTarget` is actually `<details>` not `<details-dialog>`. This change makes sure we query inside of `details-dialog` instead of `details`.