### PR TITLE
Escape event boundary + focus return to activeElement

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,5 +84,7 @@
       </div>
     </details-dialog>
   </details>
+
+  <button type="button" class="btn mt-4" onclick="document.querySelector('details').open = true">JS trigger: focus should return here</button>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -61,8 +61,8 @@ function toggle(event) {
     for (const form of dialog.querySelectorAll('form')) {
       form.reset()
     }
-    const {activeElement} = initialized.get(dialog)
-    if (activeElement) activeElement.focus()
+    const activeElement = initialized.get(dialog).activeElement || details.querySelector('summary') || document.body
+    activeElement.focus()
     details.removeEventListener('keydown', keydown)
   }
 }

--- a/index.js
+++ b/index.js
@@ -51,13 +51,18 @@ function toggle(event) {
   const dialog = details.querySelector('details-dialog')
 
   if (details.open) {
+    if (document.activeElement) {
+      initialized.set(dialog, {details, activeElement: document.activeElement})
+    }
+
     autofocus(dialog)
     details.addEventListener('keydown', keydown)
   } else {
     for (const form of dialog.querySelectorAll('form')) {
       form.reset()
     }
-    details.querySelector('summary').focus()
+    const {activeElement} = initialized.get(dialog)
+    if (activeElement) activeElement.focus()
     details.removeEventListener('keydown', keydown)
   }
 }

--- a/index.js
+++ b/index.js
@@ -61,8 +61,8 @@ function toggle(event) {
     for (const form of dialog.querySelectorAll('form')) {
       form.reset()
     }
-    const activeElement = initialized.get(dialog).activeElement || details.querySelector('summary') || document.body
-    activeElement.focus()
+    const activeElement = initialized.get(dialog).activeElement || details.querySelector('summary')
+    if (activeElement) activeElement.focus()
     details.removeEventListener('keydown', keydown)
   }
 }

--- a/index.js
+++ b/index.js
@@ -61,8 +61,9 @@ function toggle(event) {
     for (const form of dialog.querySelectorAll('form')) {
       form.reset()
     }
-    const activeElement = initialized.get(dialog).activeElement || details.querySelector('summary')
-    if (activeElement) activeElement.focus()
+    const {activeElement} = initialized.get(dialog)
+    const focusElement = activeElement === document.body ? details.querySelector('summary') : activeElement
+    if (focusElement) focusElement.focus()
     details.removeEventListener('keydown', keydown)
   }
 }

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ function autofocus(el) {
 function keydown(event) {
   if (event.key === 'Escape') {
     event.currentTarget.open = false
+    event.stopPropagation()
   } else if (event.key === 'Tab') {
     restrictTabBehavior(event)
   }


### PR DESCRIPTION
It's been tricky trying to work around the event order of returning focus on `esc` from outside of details-dialog code. So I changed the code here to return focus to `activeElement` (in most case it'd be `summary`) instead of querying directly for `summary`.

I'd have added tests for this but looks `activeElement` is always `body` unless `focus` is called directly on elements. 🤔 