### PR TITLE
Click summary to close dialog so it can be canceled

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function toggle(event: Event): void {
   }
 }
 
-function findFocusElement(details, dialog): ?HTMLElement {
+function findFocusElement(details: Element, dialog: DetailsDialogElement): ?HTMLElement {
   const state = initialized.get(dialog)
   if (state && state.activeElement instanceof HTMLElement) {
     return state.activeElement
@@ -91,7 +91,7 @@ function findFocusElement(details, dialog): ?HTMLElement {
   }
 }
 
-function toggleDetails(details, open) {
+function toggleDetails(details: Element, open: boolean) {
   // Don't update unless state is changing
   if (open === details.hasAttribute('open')) return
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function keydown(event: KeyboardEvent): void {
   const details = event.currentTarget
   if (!(details instanceof Element)) return
   if (event.key === 'Escape') {
-    details.removeAttribute('open')
+    toggleDetails(details, false)
     event.stopPropagation()
   } else if (event.key === 'Tab') {
     restrictTabBehavior(event)
@@ -91,6 +91,20 @@ function findFocusElement(details, dialog): ?HTMLElement {
   }
 }
 
+function toggleDetails(details, open) {
+  // Don't update unless state is changing
+  if (open === details.hasAttribute('open')) return
+
+  const summary = details.querySelector('summary')
+  if (summary) {
+    // Toggle via clicking summary so it can be canceled by listeners wanting
+    // to prevent the toggle
+    summary.click()
+  } else {
+    open ? details.setAttribute('open', 'open') : details.removeAttribute('open')
+  }
+}
+
 type State = {|
   details: ?Element,
   activeElement: ?Element
@@ -116,7 +130,7 @@ class DetailsDialogElement extends HTMLElement {
       if (!(target instanceof Element)) return
       const details = target.closest('details')
       if (details && target.closest(CLOSE_SELECTOR)) {
-        details.removeAttribute('open')
+        toggleDetails(details, false)
       }
     })
   }
@@ -147,7 +161,7 @@ class DetailsDialogElement extends HTMLElement {
     if (!state) return
     const {details} = state
     if (!details) return
-    open ? details.setAttribute('open', 'open') : details.removeAttribute('open')
+    toggleDetails(details, open)
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -71,10 +71,7 @@ describe('details-dialog-element', function() {
       dialog.toggle(true)
       await waitForToggleEvent(details)
       assert(details.open)
-      const escapeEvent = document.createEvent('Event')
-      escapeEvent.initEvent('keydown', true, true)
-      escapeEvent.key = 'Escape'
-      details.dispatchEvent(escapeEvent)
+      pressEscape(details)
       assert(!details.open)
     })
 
@@ -104,18 +101,19 @@ describe('details-dialog-element', function() {
 
       close.click()
       assert(details.open)
-      assert.equal(1, closeRequestCount)
+      assert.equal(closeRequestCount, 1)
 
       summary.click()
       assert(details.open)
-      assert.equal(2, closeRequestCount)
+      assert.equal(closeRequestCount, 2)
 
-      const escapeEvent = document.createEvent('Event')
-      escapeEvent.initEvent('keydown', true, true)
-      escapeEvent.key = 'Escape'
-      details.dispatchEvent(escapeEvent)
+      pressEscape(details)
       assert(details.open)
-      assert.equal(3, closeRequestCount)
+      assert.equal(closeRequestCount, 3)
+
+      dialog.toggle(false)
+      assert(details.open)
+      assert.equal(closeRequestCount, 4)
 
       allowCloseToHappen = true
       close.click()
@@ -134,4 +132,11 @@ function waitForToggleEvent(details) {
       {once: true}
     )
   })
+}
+
+function pressEscape(details) {
+  const escapeEvent = document.createEvent('Event')
+  escapeEvent.initEvent('keydown', true, true)
+  escapeEvent.key = 'Escape'
+  details.dispatchEvent(escapeEvent)
 }

--- a/test/test.js
+++ b/test/test.js
@@ -14,6 +14,11 @@ describe('details-dialog-element', function() {
   })
 
   describe('after tree insertion', function() {
+    let details
+    let dialog
+    let summary
+    let close
+
     beforeEach(function() {
       const container = document.createElement('div')
       container.innerHTML = `
@@ -26,6 +31,11 @@ describe('details-dialog-element', function() {
         </details>
       `
       document.body.append(container)
+
+      details = document.querySelector('details')
+      dialog = details.querySelector('details-dialog')
+      summary = details.querySelector('summary')
+      close = dialog.querySelector(CLOSE_SELECTOR)
     })
 
     afterEach(function() {
@@ -33,8 +43,6 @@ describe('details-dialog-element', function() {
     })
 
     it('toggles open', function() {
-      const details = document.querySelector('details')
-      const dialog = details.querySelector('details-dialog')
       assert(!details.open)
       dialog.toggle(true)
       assert(details.open)
@@ -43,9 +51,6 @@ describe('details-dialog-element', function() {
     })
 
     it('closes with close button', function() {
-      const details = document.querySelector('details')
-      const dialog = details.querySelector('details-dialog')
-      const close = dialog.querySelector(CLOSE_SELECTOR)
       assert(!details.open)
       dialog.toggle(true)
       assert(details.open)
@@ -54,9 +59,6 @@ describe('details-dialog-element', function() {
     })
 
     it('closes when summary is clicked', function() {
-      const details = document.querySelector('details')
-      const summary = document.querySelector('summary')
-      const dialog = details.querySelector('details-dialog')
       assert(!details.open)
       dialog.toggle(true)
       assert(details.open)
@@ -65,8 +67,6 @@ describe('details-dialog-element', function() {
     })
 
     it('closes when escape key is pressed', async function() {
-      const details = document.querySelector('details')
-      const dialog = details.querySelector('details-dialog')
       assert(!details.open)
       dialog.toggle(true)
       await waitForToggleEvent(details)
@@ -75,12 +75,7 @@ describe('details-dialog-element', function() {
       assert(!details.open)
     })
 
-    it('supports canceling requests to close the dialog', async function() {
-      const details = document.querySelector('details')
-      const summary = document.querySelector('summary')
-      const dialog = details.querySelector('details-dialog')
-      const close = dialog.querySelector(CLOSE_SELECTOR)
-
+    it('supports canceling requests to close the dialog when a summary element is present', async function() {
       dialog.toggle(true)
       await waitForToggleEvent(details)
       assert(details.open)
@@ -118,6 +113,37 @@ describe('details-dialog-element', function() {
       allowCloseToHappen = true
       close.click()
       assert(!details.open)
+    })
+
+    describe('when no summary element is present', function() {
+      beforeEach(function() {
+        summary.remove()
+      })
+
+      it('toggles open', function() {
+        assert(!details.open)
+        dialog.toggle(true)
+        assert(details.open)
+        dialog.toggle(false)
+        assert(!details.open)
+      })
+
+      it('closes with close button', function() {
+        assert(!details.open)
+        dialog.toggle(true)
+        assert(details.open)
+        close.click()
+        assert(!details.open)
+      })
+
+      it('closes when escape key is pressed', async function() {
+        assert(!details.open)
+        dialog.toggle(true)
+        await waitForToggleEvent(details)
+        assert(details.open)
+        pressEscape(details)
+        assert(!details.open)
+      })
     })
   })
 })


### PR DESCRIPTION
This pull request changes the toggling of the dialog to click the `<summary>` element instead of directly setting the `open` attribute on the `<details>` element.

This allows listeners to listen to the `click` event on the `<summary>` and prevent it so the dialog will not close.

The plan is to use this to add some confirm on close behavior so that closing the dialog can be aborted if the user does not confirm they want to discard unsaved changes to the form inside the dialog.