### PR TITLE
Add cancellable details-dialog:will-close event

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,24 @@ import 'details-dialog-element'
 </details>
 ```
 
+## Events
+
+### `details-dialog:will-close`
+
+A `details-dialog:will-close` event is fired when a request to close the dialog
+is made either by pressing escape, clicking the close button, clicking outside
+the dialog, or when `.toggle(false)` is called on an open dialog.
+
+This event can be cancelled to keep the dialog open.
+
+```js
+document.addEventListener('details-dialog:will-close', function(event) {
+  if (!confirm("Are you sure?")) {
+    event.preventDefault()
+  }
+})
+```
+
 ## Browser support
 
 Browsers without native [custom element support][support] require a [polyfill][].

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This event can be cancelled to keep the dialog open.
 
 ```js
 document.addEventListener('details-dialog:will-close', function(event) {
-  if (!confirm("Are you sure?")) {
+  if (!confirm('Are you sure?')) {
     event.preventDefault()
   }
 })

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ import 'details-dialog-element'
 ### `details-dialog:will-close`
 
 A `details-dialog:will-close` event is fired when a request to close the dialog
-is made either by pressing escape, clicking the close button, clicking outside
-the dialog, or when `.toggle(false)` is called on an open dialog.
+is made either by pressing escape, clicking a `data-close-dialog` element,
+clicking on the `<summary>` element, or when `.toggle(false)` is called on an
+open dialog.
 
 This event can be cancelled to keep the dialog open.
 

--- a/index.js
+++ b/index.js
@@ -177,8 +177,8 @@ class DetailsDialogElement extends HTMLElement {
     if (!state) return
     const {details} = state
     if (!details) return
-    const summary = details.querySelector('summary')
     details.removeEventListener('toggle', toggle)
+    const summary = details.querySelector('summary')
     if (summary) {
       summary.removeEventListener('click', onSummaryClick, {capture: true})
     }

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ function allowClosingDialog(details: Element): boolean {
   )
 }
 
-function onSummaryClick(event: MouseEvent) {
+function onSummaryClick(event: Event) {
   if (!(event.currentTarget instanceof Element)) return
 
   const details = event.currentTarget.closest('details[open]')

--- a/index.js
+++ b/index.js
@@ -59,22 +59,25 @@ function restrictTabBehavior(event: KeyboardEvent): void {
   elements[targetIndex].focus()
 }
 
+function allowClosingDialog(details: Element): boolean {
+  const dialog = details.querySelector('details-dialog')
+  if (!(dialog instanceof DetailsDialogElement)) return true
+
+  return dialog.dispatchEvent(
+    new CustomEvent('details-dialog:will-close', {
+      bubbles: true,
+      cancelable: true
+    })
+  )
+}
+
 function onSummaryClick(event: MouseEvent) {
   if (!(event.currentTarget instanceof Element)) return
 
   const details = event.currentTarget.closest('details[open]')
   if (!details) return
 
-  const dialog = details.querySelector('details-dialog')
-  if (!dialog) return
-
-  const preventSummaryClick = !dialog.dispatchEvent(
-    new CustomEvent('details-dialog:will-close', {
-      bubbles: true,
-      cancelable: true
-    })
-  )
-
+  const preventSummaryClick = !allowClosingDialog(details)
   if (preventSummaryClick) {
     event.preventDefault()
     event.stopPropagation()
@@ -117,11 +120,10 @@ function toggleDetails(details: Element, open: boolean) {
   // Don't update unless state is changing
   if (open === details.hasAttribute('open')) return
 
-  const summary = details.querySelector('summary')
-  if (summary) {
-    summary.click()
-  } else {
-    open ? details.setAttribute('open', '') : details.removeAttribute('open')
+  if (open) {
+    details.setAttribute('open', '')
+  } else if (allowClosingDialog(details)) {
+    details.removeAttribute('open')
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -73,12 +73,11 @@ function allowClosingDialog(details: Element): boolean {
 
 function onSummaryClick(event: Event) {
   if (!(event.currentTarget instanceof Element)) return
-
   const details = event.currentTarget.closest('details[open]')
   if (!details) return
 
-  const preventSummaryClick = !allowClosingDialog(details)
-  if (preventSummaryClick) {
+  // Prevent summary click events if details-dialog:will-close was cancelled
+  if (!allowClosingDialog(details)) {
     event.preventDefault()
     event.stopPropagation()
   }

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ function toggleDetails(details: Element, open: boolean) {
     // to prevent the toggle
     summary.click()
   } else {
-    open ? details.setAttribute('open', 'open') : details.removeAttribute('open')
+    open ? details.setAttribute('open', '') : details.removeAttribute('open')
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ function allowClosingDialog(details: Element): boolean {
   )
 }
 
-function onSummaryClick(event: Event) {
+function onSummaryClick(event: Event): void {
   if (!(event.currentTarget instanceof Element)) return
   const details = event.currentTarget.closest('details[open]')
   if (!details) return

--- a/test/test.js
+++ b/test/test.js
@@ -75,15 +75,15 @@ describe('details-dialog-element', function() {
       assert(!details.open)
     })
 
-    it('supports canceling requests to close the dialog when a summary element is present', async function() {
+    it('supports a cancellable details-dialog:will-close event when a summary element is present', async function() {
       dialog.toggle(true)
       await waitForToggleEvent(details)
       assert(details.open)
 
       let closeRequestCount = 0
       let allowCloseToHappen = false
-      summary.addEventListener(
-        'click',
+      dialog.addEventListener(
+        'details-dialog:will-close',
         function(event) {
           closeRequestCount++
           if (!allowCloseToHappen) {

--- a/test/test.js
+++ b/test/test.js
@@ -120,6 +120,42 @@ describe('details-dialog-element', function() {
         summary.remove()
       })
 
+      it('supports a cancellable details-dialog:will-close event', async function() {
+        dialog.toggle(true)
+        await waitForToggleEvent(details)
+        assert(details.open)
+
+        let closeRequestCount = 0
+        let allowCloseToHappen = false
+        dialog.addEventListener(
+          'details-dialog:will-close',
+          function(event) {
+            closeRequestCount++
+            if (!allowCloseToHappen) {
+              event.preventDefault()
+              event.stopPropagation()
+            }
+          },
+          {capture: true}
+        )
+
+        close.click()
+        assert(details.open)
+        assert.equal(closeRequestCount, 1)
+
+        pressEscape(details)
+        assert(details.open)
+        assert.equal(closeRequestCount, 2)
+
+        dialog.toggle(false)
+        assert(details.open)
+        assert.equal(closeRequestCount, 3)
+
+        allowCloseToHappen = true
+        close.click()
+        assert(!details.open)
+      })
+
       it('toggles open', function() {
         assert(!details.open)
         dialog.toggle(true)


### PR DESCRIPTION
Adds a `details-dialog:will-close` event when the summary is clicked that can be cancelled to prevent the dialog from closing.

Refs https://github.com/github/details-dialog-element/pull/21#pullrequestreview-155152495