### PR TITLE
Consider hidden parent element in focus management

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ function restrictTabBehavior(event: KeyboardEvent): void {
   event.preventDefault()
 
   const elements: Array<Focusable> = Array.from(dialog.querySelectorAll(INPUT_SELECTOR)).filter(focusable)
+  if (elements.length === 0) return
 
   const movement = event.shiftKey ? -1 : 1
   const currentFocus = elements.filter(el => el.matches(':focus'))[0]

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function restrictTabBehavior(event: KeyboardEvent): void {
 
   const movement = event.shiftKey ? -1 : 1
   const currentFocus = elements.filter(el => el.matches(':focus'))[0]
-  let targetIndex = elements.length - 1
+  let targetIndex = 0
 
   if (currentFocus) {
     const currentIndex = elements.indexOf(currentFocus)

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function keydown(event: KeyboardEvent): void {
 }
 
 function focusable(el: Focusable): boolean {
-  return !el.disabled && !el.hidden && (!el.type || el.type !== 'hidden')
+  return !el.disabled && !el.hidden && (!el.type || el.type !== 'hidden') && !el.closest('[hidden]')
 }
 
 function restrictTabBehavior(event: KeyboardEvent): void {

--- a/test/test.js
+++ b/test/test.js
@@ -26,6 +26,9 @@ describe('details-dialog-element', function() {
           <summary>Click</summary>
           <details-dialog>
             <p>Hello</p>
+            <button data-button>Button</button>
+            <button hidden>hidden</button>
+            <div hidden><button>hidden</button></div>
             <button ${CLOSE_ATTR}>Goodbye</button>
           </details-dialog>
         </details>
@@ -73,6 +76,16 @@ describe('details-dialog-element', function() {
       assert(details.open)
       pressEscape(details)
       assert(!details.open)
+    })
+
+    it('manages focus', async function() {
+      summary.click()
+      await waitForToggleEvent(details)
+      assert.equal(document.activeElement, dialog)
+      pressTab(details)
+      assert.equal(document.activeElement, document.querySelector(`[data-button]`))
+      pressTab(details)
+      assert.equal(document.activeElement, document.querySelector(`[${CLOSE_ATTR}]`))
     })
 
     it('supports a cancellable details-dialog:will-close event when a summary element is present', async function() {
@@ -200,5 +213,12 @@ function pressEscape(details) {
   const escapeEvent = document.createEvent('Event')
   escapeEvent.initEvent('keydown', true, true)
   escapeEvent.key = 'Escape'
+  details.dispatchEvent(escapeEvent)
+}
+
+function pressTab(details) {
+  const escapeEvent = document.createEvent('Event')
+  escapeEvent.initEvent('keydown', true, true)
+  escapeEvent.key = 'Tab'
   details.dispatchEvent(escapeEvent)
 }


### PR DESCRIPTION
- Add tests for tab trapping
- Check if parent element is hidden in `focusable()`
- Fix starting focus target index (previously the first element to focus was the last one)
- Prevent error being thrown when nothing is focusable in a dialog