### PR TITLE
Fix the escape key when running under IE11

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function autofocus(el: DetailsDialogElement): void {
 function keydown(event: KeyboardEvent): void {
   const details = event.currentTarget
   if (!(details instanceof Element)) return
-  if (event.key === 'Escape') {
+  if (event.key === 'Escape' || event.key === 'Esc') {
     toggleDetails(details, false)
     event.stopPropagation()
   } else if (event.key === 'Tab') {


### PR DESCRIPTION
I'm using this under the full WebComponents polyfill,
plus a polyfill for `.closest`.