### PR TITLE
Fix autofocusing when details is not open & preload toggling

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,12 +236,13 @@ class DetailsDialogElement extends HTMLElement {
 
     if (this.src) {
       details.addEventListener('toggle', loadIncludeFragment, {once: true})
-
-      if (this.preload) {
-        details.addEventListener('mouseover', loadIncludeFragment, {once: true})
-      }
     } else {
       details.removeEventListener('toggle', loadIncludeFragment)
+    }
+
+    if (this.src && this.preload) {
+      details.addEventListener('mouseover', loadIncludeFragment, {once: true})
+    } else {
       details.removeEventListener('mouseover', loadIncludeFragment)
     }
   }

--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ function loadIncludeFragment(event: Event) {
   if (src === null) return
 
   loader.addEventListener('loadend', () => {
-    autofocus(dialog)
+    if (details.hasAttribute('open')) autofocus(dialog)
   })
   loader.setAttribute('src', src)
 }


### PR DESCRIPTION
Found two issues while upgrading:

1. on mouseover `preload` triggers and `autofocus` is called even though dialog is still closed
2. removing `preload` attribute while `src` is present does not remove the event listener because `removeEventListener` is only called when `this.src` is falsey.