### PR TITLE
Add aria-modal

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,6 +188,7 @@ class DetailsDialogElement extends HTMLElement {
 
   connectedCallback() {
     this.setAttribute('role', 'dialog')
+    this.setAttribute('aria-modal', 'true')
     const state = initialized.get(this)
     if (!state) return
     const details = this.parentElement


### PR DESCRIPTION
I didn't add [`aria-modal`](https://www.w3.org/TR/wai-aria-1.1/#aria-modal) previously because the browser support was questionable. I filed https://bugs.chromium.org/p/chromium/issues/detail?id=716592 to Chrome 2 years ago, but there hasn't been progress. Testing showed that this at least works with Safari in with VoiceOver.
