### PR TITLE
Remove aria-haspopup=dialog and add role=button

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ class DetailsDialogElement extends HTMLElement {
 
     const summary = details.querySelector('summary')
     if (summary) {
-      summary.setAttribute('aria-haspopup', 'dialog')
+      summary.setAttribute('role', 'button')
       summary.addEventListener('click', onSummaryClick, {capture: true})
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -45,6 +45,12 @@ describe('details-dialog-element', function() {
       document.body.innerHTML = ''
     })
 
+    it('initializes', function() {
+      assert.equal(summary.getAttribute('role'), 'button')
+      assert.equal(dialog.getAttribute('role'), 'dialog')
+      assert.equal(dialog.getAttribute('aria-modal'), 'true')
+    })
+
     it('toggles open', function() {
       assert(!details.open)
       dialog.toggle(true)


### PR DESCRIPTION
Fixes #34. 

1. Remove `aria-haspopup="dialog"` from `<summary>` due to poor support creating negative user experience. For reference, here's [an open issue on NVDA]( https://github.com/nvaccess/nvda/issues/8235) for reference. We can revisit this down the line.

2. Add `role="button"` to `<summary>`. A dialog's trigger element should be announced as a button.