### PR TITLE
Avoid setting role attribute if attribute is present

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ class DetailsDialogElement extends HTMLElement {
 
     const summary = details.querySelector('summary')
     if (summary) {
-      summary.setAttribute('role', 'button')
+      if (!summary.hasAttribute('role')) summary.setAttribute('role', 'button')
       summary.addEventListener('click', onSummaryClick, {capture: true})
     }
 


### PR DESCRIPTION
This conflicts with `<details-menu>`'s role requirement.