### PR TITLE
Add TS window declaration for DetailsDialogElement

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,6 @@ export default class DetailsDialogElement extends HTMLElement {
 
 declare global {
   interface Window {
-    DetailsDialogElement: DetailsDialogElement
+    DetailsDialogElement: typeof DetailsDialogElement
   }
 }


### PR DESCRIPTION
The TypeScript definition is incomplete as it doesn't properly reflect the assignment to Window.

This PR adds the declaration of `DetailsDialogElement` to the global window object, as that mutation is happening within the code and so should be reflected in the types.

 Refs https://github.com/github/application-architecture/issues/58