### PR TITLE
Include module in Flow declaration

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -1,5 +1,7 @@
 /* @flow strict */
 
-declare class DetailsDialogElement extends HTMLElement {
-  toggle(open: boolean): void;
+declare module '@github/details-dialog-element' {
+  declare export default class DetailsDialogElement extends HTMLElement {
+    toggle(open: boolean): void;
+  }
 }


### PR DESCRIPTION
Fixes an error importing the class.

```js
import DetailsDialogElement from '@github/details-dialog-element
```
> Error: Importing from an untyped module makes it `any` and is not safe!