### PR TITLE
Ensure focusble targets are visible

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,18 @@ function keydown(event: KeyboardEvent): void {
 }
 
 function focusable(el: Focusable): boolean {
-  return el.tabIndex >= 0 && !el.disabled && !el.hidden && (!el.type || el.type !== 'hidden') && !el.closest('[hidden]')
+  return (
+    el.tabIndex >= 0 &&
+    !el.disabled &&
+    !el.hidden &&
+    (!el.type || el.type !== 'hidden') &&
+    !el.closest('[hidden]') &&
+    visible(el)
+  )
+}
+
+function visible(el): boolean {
+  return el.offsetWidth > 0 || el.offsetHeight > 0
 }
 
 function restrictTabBehavior(event: KeyboardEvent): void {

--- a/index.js
+++ b/index.js
@@ -32,11 +32,11 @@ function keydown(event: KeyboardEvent): void {
 }
 
 function focusable(el: Focusable): boolean {
-  return el.tabIndex >= 0 && !el.disabled && !el.hidden && (!el.type || el.type !== 'hidden') && visible(el)
+  return el.tabIndex >= 0 && !el.disabled && visible(el)
 }
 
 function visible(el): boolean {
-  return el.offsetWidth > 0 || el.offsetHeight > 0
+  return !el.hidden && (!el.type || el.type !== 'hidden') && (el.offsetWidth > 0 || el.offsetHeight > 0)
 }
 
 function restrictTabBehavior(event: KeyboardEvent): void {

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ type Focusable =
   | HTMLElement
 
 function autofocus(el: DetailsDialogElement): void {
-  let autofocusElement = el.querySelector('[autofocus]')
+  let autofocusElement = Array.from(el.querySelectorAll('[autofocus]')).filter(focusable)[0]
   if (!autofocusElement) {
     autofocusElement = el
     el.setAttribute('tabindex', '-1')

--- a/index.js
+++ b/index.js
@@ -32,14 +32,7 @@ function keydown(event: KeyboardEvent): void {
 }
 
 function focusable(el: Focusable): boolean {
-  return (
-    el.tabIndex >= 0 &&
-    !el.disabled &&
-    !el.hidden &&
-    (!el.type || el.type !== 'hidden') &&
-    !el.closest('[hidden]') &&
-    visible(el)
-  )
+  return el.tabIndex >= 0 && !el.disabled && !el.hidden && (!el.type || el.type !== 'hidden') && visible(el)
 }
 
 function visible(el): boolean {

--- a/test/test.js
+++ b/test/test.js
@@ -29,6 +29,7 @@ describe('details-dialog-element', function() {
             <button data-button>Button</button>
             <button hidden>hidden</button>
             <div hidden><button>hidden</button></div>
+            <details><button>Button in closed details</button></details>
             <button ${CLOSE_ATTR}>Goodbye</button>
           </details-dialog>
         </details>


### PR DESCRIPTION
Fixes #41, refer to considerations in https://github.com/github/details-dialog-element/issues/41#issuecomment-512864096.

This is a reliable visibility check (which comes with a perf cost as it triggers layout). I kept `.hidden` and `type=hidden` checks because they're relatively cheap and we use them often. When they were true we skip some `visible` calls.

Example use case:

```html
<details-dialog>
  <details>
    <details-menu><button><!-- focusable but not visible --></button></details-menu>
  </details>
</details-dialog>
```

and for autofocus:


```html
<details-dialog>
  <details>
    <details-menu><input autofocus><!-- focusable but not visible --></details-menu>
  </details>
  <button autofocus></button>
</details-dialog>
```
