### PR TITLE
Fix shift tab when currentIndex is 0 or -1

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function restrictTabBehavior(event: KeyboardEvent): void {
   if (elements.length === 0) return
 
   const movement = event.shiftKey ? -1 : 1
-  const currentFocus = elements.filter(el => el.matches(':focus'))[0]
+  const currentFocus = dialog.contains(document.activeElement) ? document.activeElement : null
   let targetIndex = 0
 
   if (currentFocus) {

--- a/index.js
+++ b/index.js
@@ -56,7 +56,11 @@ function restrictTabBehavior(event: KeyboardEvent): void {
     const currentIndex = elements.indexOf(currentFocus)
     if (currentIndex !== -1) {
       const newIndex = currentIndex + movement
-      if (newIndex >= 0) targetIndex = newIndex % elements.length
+      if (newIndex < 0) {
+        targetIndex = elements.length - 1
+      } else {
+        targetIndex = newIndex % elements.length
+      }
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -50,18 +50,19 @@ function restrictTabBehavior(event: KeyboardEvent): void {
 
   const movement = event.shiftKey ? -1 : 1
   const currentFocus = dialog.contains(document.activeElement) ? document.activeElement : null
-  let targetIndex = 0
+  let targetIndex = movement === -1 ? -1 : 0
 
   if (currentFocus) {
     const currentIndex = elements.indexOf(currentFocus)
     if (currentIndex !== -1) {
-      const newIndex = currentIndex + movement
-      if (newIndex < 0) {
-        targetIndex = elements.length - 1
-      } else {
-        targetIndex = newIndex % elements.length
-      }
+      targetIndex = currentIndex + movement
     }
+  }
+
+  if (targetIndex < 0) {
+    targetIndex = elements.length - 1
+  } else {
+    targetIndex = targetIndex % elements.length
   }
 
   elements[targetIndex].focus()

--- a/test/test.js
+++ b/test/test.js
@@ -81,7 +81,7 @@ describe('details-dialog-element', function() {
       dialog.toggle(true)
       await waitForToggleEvent(details)
       assert(details.open)
-      pressEscape(details)
+      triggerKeydownEvent(details, 'Escape')
       assert(!details.open)
     })
 
@@ -89,11 +89,11 @@ describe('details-dialog-element', function() {
       summary.click()
       await waitForToggleEvent(details)
       assert.equal(document.activeElement, dialog)
-      pressTab(details, true)
+      triggerKeydownEvent(details, 'Tab', true)
       assert.equal(document.activeElement, document.querySelector(`[${CLOSE_ATTR}]`))
-      pressTab(details)
+      triggerKeydownEvent(details, 'Tab')
       assert.equal(document.activeElement, document.querySelector(`[data-button]`))
-      pressTab(details)
+      triggerKeydownEvent(details, 'Tab')
       assert.equal(document.activeElement, document.querySelector(`[${CLOSE_ATTR}]`))
     })
 
@@ -124,7 +124,7 @@ describe('details-dialog-element', function() {
       assert(details.open)
       assert.equal(closeRequestCount, 2)
 
-      pressEscape(details)
+      triggerKeydownEvent(details, 'Escape')
       assert(details.open)
       assert.equal(closeRequestCount, 3)
 
@@ -165,7 +165,7 @@ describe('details-dialog-element', function() {
         assert(details.open)
         assert.equal(closeRequestCount, 1)
 
-        pressEscape(details)
+        triggerKeydownEvent(details, 'Escape')
         assert(details.open)
         assert.equal(closeRequestCount, 2)
 
@@ -199,7 +199,7 @@ describe('details-dialog-element', function() {
         dialog.toggle(true)
         await waitForToggleEvent(details)
         assert(details.open)
-        pressEscape(details)
+        triggerKeydownEvent(details, 'Escape')
         assert(!details.open)
       })
     })
@@ -232,7 +232,7 @@ describe('details-dialog-element', function() {
         dialog.preload = true
         assert(dialog.hasAttribute('preload'))
         assert.notOk(includeFragment.getAttribute('src'))
-        triggerEvent(details, 'mouseover')
+        triggerMouseoverEvent(details)
         assert.equal(includeFragment.getAttribute('src'), '/404')
       })
     })
@@ -262,7 +262,7 @@ describe('details-dialog-element', function() {
       it('transfers src on mouseover', async function() {
         assert(!details.open)
         assert.notOk(includeFragment.getAttribute('src'))
-        triggerEvent(details, 'mouseover')
+        triggerMouseoverEvent(details)
         assert.equal(includeFragment.getAttribute('src'), '/404')
       })
     })
@@ -281,22 +281,21 @@ function waitForToggleEvent(details) {
   })
 }
 
-function triggerEvent(element, name, key, shiftKey) {
-  const eventklass = name.match(/^mouse/) ? MouseEvent : KeyboardEvent
+function triggerMouseoverEvent(element) {
   element.dispatchEvent(
-    new eventklass(name, {
+    new MouseEvent('mouseover', {
+      bubbles: true,
+      cancelable: true
+    })
+  )
+}
+function triggerKeydownEvent(element, key, shiftKey) {
+  element.dispatchEvent(
+    new KeyboardEvent('keydown', {
       bubbles: true,
       cancelable: true,
       key,
       shiftKey
     })
   )
-}
-
-function pressEscape(details) {
-  triggerEvent(details, 'keydown', 'Escape')
-}
-
-function pressTab(details, shift) {
-  triggerEvent(details, 'keydown', 'Tab', shift)
 }

--- a/test/test.js
+++ b/test/test.js
@@ -89,6 +89,8 @@ describe('details-dialog-element', function() {
       summary.click()
       await waitForToggleEvent(details)
       assert.equal(document.activeElement, dialog)
+      pressTab(details, true)
+      assert.equal(document.activeElement, document.querySelector(`[${CLOSE_ATTR}]`))
       pressTab(details)
       assert.equal(document.activeElement, document.querySelector(`[data-button]`))
       pressTab(details)
@@ -279,17 +281,22 @@ function waitForToggleEvent(details) {
   })
 }
 
-function triggerEvent(element, name, key) {
-  const event = document.createEvent('Event')
-  event.initEvent(name, true, true)
-  if (key) event.key = key
-  element.dispatchEvent(event)
+function triggerEvent(element, name, key, shiftKey) {
+  const eventklass = name.match(/^mouse/) ? MouseEvent : KeyboardEvent
+  element.dispatchEvent(
+    new eventklass(name, {
+      bubbles: true,
+      cancelable: true,
+      key,
+      shiftKey
+    })
+  )
 }
 
 function pressEscape(details) {
   triggerEvent(details, 'keydown', 'Escape')
 }
 
-function pressTab(details) {
-  triggerEvent(details, 'keydown', 'Tab')
+function pressTab(details, shift) {
+  triggerEvent(details, 'keydown', 'Tab', shift)
 }


### PR DESCRIPTION
I will comment inline to point out where the bugs come from.

Bonus: instead of `.initEvent` this updates the test to use the proper event class constructors.