### PR TITLE
Fix getRootNode not available in Edge 18

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ function toggle(event: Event): void {
   if (!(dialog instanceof DetailsDialogElement)) return
 
   if (details.hasAttribute('open')) {
-    const root = dialog.getRootNode() as Document | ShadowRoot
+    const root = 'getRootNode' in dialog ? (dialog.getRootNode() as Document | ShadowRoot) : document
     if (root.activeElement instanceof HTMLElement) {
       initialized.set(dialog, {details, activeElement: root.activeElement})
     }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode

We polyfill custom elements in Edge 18 but they don't have getRootNode.