### PR TITLE
Fix preload + src bug with include-fragment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -152,6 +152,7 @@ function loadIncludeFragment(event: Event) {
     if (details.hasAttribute('open')) autofocus(dialog)
   })
   loader.setAttribute('src', src)
+  removeIncludeFragmentEventListeners(details)
 }
 
 function updateIncludeFragmentEventListeners(details: Element, src: string | null, preload: boolean) {


### PR DESCRIPTION
When a dialog has `src` as well as `preload` set, we add two listeners, one for `toggle` and another for `mouseover` for `preload`. Both listeners are set with `once` flag. The bug appears when:

1. On `mouseover` summary, `src` is set on `include-fragment`
2. `include-fragment[src]` loads
3. At this point `toggle` listener still exists, so on `toggle` it tries to find an `include-fragment` again
4. Now if the dialog contains a second `include-fragment`, it will have the `src` set

This PR fixes the issue by removing the remaining listeners as soon as `src` is set.