### PR TITLE
Make sure to scroll any overflow

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -9,5 +9,5 @@ details-dialog {
   max-height: 80vh;
   max-width: 90vw;
   width: 448px;
-  overflow: scroll;
+  overflow: auto;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -9,4 +9,5 @@ details-dialog {
   max-height: 80vh;
   max-width: 90vw;
   width: 448px;
+  overflow: scroll;
 }


### PR DESCRIPTION
Make sure that the dialog is scrollable when the dialog is larger than the display. You can test out this change on the example page by making the browser window smaller in height than the dialog. See the example section for examples.

## Examples

### Before this change
https://user-images.githubusercontent.com/318208/133088892-19069f03-530e-471b-b6b3-f7d714269d2f.mov

### After this change
https://user-images.githubusercontent.com/318208/133088899-d3b4e484-fd2c-494b-8a75-c0445112d0ae.mov

