### PR TITLE
Check if elements is in a closed details element

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ function focusable(el: Target): boolean {
 function visible(el: Target): boolean {
   return (
     !el.hidden &&
+    !el.closest('details:not([open])') &&
     (!(el as Disableable).type || (el as Disableable).type !== 'hidden') &&
     (el.offsetWidth > 0 || el.offsetHeight > 0)
   )

--- a/test/test.js
+++ b/test/test.js
@@ -89,7 +89,7 @@ describe('details-dialog-element', function() {
       assert(!details.open)
     })
 
-    it.skip('manages focus', async function() {
+    it('manages focus', async function() {
       summary.click()
       await waitForToggleEvent(details)
       assert.equal(document.activeElement, dialog)


### PR DESCRIPTION
Consider a element as hidden if it's in a closed `<details>` element.

Closes https://github.com/github/details-dialog-element/issues/77